### PR TITLE
fix: 重なり以外の配置を決定完了

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,24 +1,98 @@
 @charset "UTF-8";
 
+body {
+    font-family: Arial;
+}
+
 .wrapper {
-    margin: 5em 10em;
+    margin: 5em auto;
+    max-width: 1040px;
 }
 
 .flex-group {
     display: flex;
-    gap: 1em;
-    justify-content: center;
+    flex-wrap: wrap; /* 折り返しを許可 */
 }
 
-#catalog-antique-group {
-    flex-direction: column;
+.footer {
+    justify-content: space-between;
+    align-items: center;
+    margin: 6.25rem auto;
+}
+
+.copyright {
+    margin: 1.875rem 0;
+}
+
+h2 {
+    font-size: 1.5rem;
+}
+
+.larger-text {
+    font-size: 0.875rem;
+    line-height: 1.3125rem;
+}
+
+.smaller-text {
+    font-size: 0.75rem;
 }
 
 .center {
     text-align: center;
 }
 
+/* ユーティリティクラス */
+
 .center-image {
     display: block;
     margin: auto;
+}
+
+.align-center {
+    display: flex;
+    align-items: center;   
+}
+
+.narrow-gap {
+    gap: 1.25rem;
+}
+
+.gap {
+    gap: 2.5rem;
+}
+
+.wide-gap {
+    gap: 7.5rem;
+}
+
+.margin-bottom-0125 {
+    margin-bottom: 0.125rem;
+}
+
+.margin-bottom-0625 {
+    margin-bottom: 0.625rem;
+}
+
+.margin-bottom-125 {
+    margin-bottom: 1.25rem;
+}
+
+.margin-bottom-1875 {
+    margin-bottom: 1.875rem;
+}
+
+.margin-bottom-25 {
+    margin-bottom: 2.5rem;
+}
+
+.margin-bottom-375 {
+    margin-bottom: 3.75rem;
+}
+
+.line-height-15 {
+    line-height: 1.5rem;
+}
+
+#catalog-antique-group {
+    flex-direction: column;
 }

--- a/index.html
+++ b/index.html
@@ -15,24 +15,24 @@
 
 <div class="wrapper">
     <div>
-        <p class="center">
+        <h2 class="center margin-bottom-125">
             A special, long article in a newspaper or magazine
-        </p>
-        <p class="center">
+        </h2>
+        <p class="center larger-text margin-bottom-25">
             テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
             <br>テキストテキストテキストテキストテキストテキストテキストテキスト
         </p>
     </div>
-    <div class="flex-group">
+    <div class="flex-group narrow-gap">
         <div>
             <div>
                 <img src="images/magazine-archive 1.png" alt="複数の本">
             </div>
             <div>
-                <p class="center">
+                <h2 class="center margin-bottom-0125">
                     Archive
-                </p>
-                <p class="center">
+                </h2>
+                <p class="center larger-text">
                     テキストテキストテキストテキスト
                     <br>テキストテキストテキスト
                 </p>
@@ -43,10 +43,10 @@
                 <img src="images/magazine-new 1.png" alt="開かれている本">
             </div>
             <div>
-                <p class="center">
+                <h2 class="center margin-bottom-0125">
                     New
-                </p>
-                <p class="center">
+                </h2>
+                <p class="center larger-text">
                     テキストテキストテキストテキスト
                     <br>テキストテキストテキスト
                 </p>
@@ -57,10 +57,10 @@
 
 <div>
     <div>
-        <p class="center">
+        <h2 class="center margin-bottom-125">
             Fashion & Style
-        </p>
-        <p class="center">
+        </h2>
+        <p class="center larger-text margin-bottom-1875">
             テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
             <br>テキストテキストテキストテキストテキストテキストテキストテキスト
         </p>
@@ -73,39 +73,43 @@
     </div>
 </div>
 
-<div id="catalog-antique-group" class="flex-group wrapper">
-    <div class="flex-group">
+<div id="catalog-antique-group" class="flex-group wrapper wide-gap">
+    <div class="flex-group align-center gap">
         <div>
             <img src="images/catalog 1.png" alt="カタログのラフ">
         </div>
         <div>
-            <p class="center">Catalog</p>
-            <p class="center">
+            <h2 class="center margin-bottom-25">
+                Catalog
+            </h2>
+            <p class="center larger-text margin-bottom-1875">
                 テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト                
             </p>
-            <p class="center">
+            <p class="center larger-text margin-bottom-1875">
                 テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト                
             </p>
-            <p class="center">
+            <p class="center larger-text">
                 テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト                
             </p>
         </div>
     </div>
-    <div class="flex-group">
+    <div class="flex-group align-center gap">
         <div>
-            <p class="center">Antique</p>
-            <p class="center">
+            <h2 class="center margin-bottom-25">
+                Antique
+            </h2>
+            <p class="center larger-text margin-bottom-1875">
                 テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト                
             </p>
-            <p class="center">
+            <p class="center larger-text margin-bottom-375">
                 テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 <br>テキストテキストテキストテキストテキストテキストテキストテキストテキスト                
@@ -120,13 +124,15 @@
     </div>
 </div>
 
-<div class="flex-group wrapper">
+<div class="flex-group wrapper footer">
     <div>
         <img src="images/logo.png" alt="ロゴ">
     </div>
     <div>
-        <p>タイトル</p>
-        <p>
+        <h4 class="margin-bottom-0625">
+            タイトル
+        </h4>
+        <p class="smaller-text line-height-15">
             - テキストテキストテキスト
             <br>- テキストテキストテキスト
             <br>- テキストテキストテキスト
@@ -135,8 +141,10 @@
         </p>
     </div>
     <div>
-        <p>タイトルタイトルタイトル</p>
-        <p>
+        <h4 class="margin-bottom-0625">
+            タイトルタイトルタイトル
+        </h4>
+        <p class="smaller-text line-height-15">
             テキストテキストテキストテキストテキストテキストテキ
             <br>ストテキストテキストテキストテキストテキストテキスト
             <br>テキストテキストテキストテキストテキストテキストテキ
@@ -146,7 +154,7 @@
     </div>
 </div>
 
-<p class="center">
+<p class="center copyright">
     © Mag88
 </p>
 </body>


### PR DESCRIPTION
- 重なり以外の配置を決定し終えました。
  - 重なりは次回以降のコミットで行います。
- 今後の方針：重なりの表現 → ボタンの調整 → 配色の確定 → レスポンシブ対応 

- ブランチを切るのを失念しており、前回のブランチにプッシュしてしまいました。
申し訳ありません。次回以降ブランチを切って作業します。

https://github.com/user-attachments/assets/13255c28-1bce-4f5f-ad64-62c71f09046b

