### PR TITLE
fix: レスポンシブ対応について、細かな修正に対応

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,7 +32,7 @@ body {
     flex-direction: column;
 }
 
-#catalog-group {
+.catalog-antique-text-group {
     max-width: 31.3125rem;
 }
 
@@ -41,6 +41,8 @@ body {
 }
 
 .footer {
+    display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
     margin: 0 auto;
@@ -200,6 +202,8 @@ h2 {
     }
 
     .footer {
+        display: flex;
+        flex-wrap: wrap;
         flex-direction: column;
         align-items: stretch; /* リセット */
         padding: 1.875rem 0 3.75rem 0;
@@ -221,5 +225,22 @@ h2 {
 
     .wide-gap {
         gap: 3.75rem;
+    }
+}
+
+@media (max-width: 581px) {
+    .footer {
+        display: flex;
+        flex-wrap: wrap;
+        flex-direction: column;
+        align-items: stretch; /* リセット */
+        padding: 1.875rem 0 3.75rem 0;
+        gap: 1.875rem;
+    }
+}
+
+@media (max-width: 1041px) {
+    .flex-group {
+        flex-direction: column;
     }
 }

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
             <div>
                 <img src="images/catalog 1.png" alt="カタログのラフ">
             </div>
-            <div>
+            <div class="catalog-antique-text-group">
                 <h2 class="center margin-bottom-25">
                     Catalog
                 </h2>
@@ -103,7 +103,7 @@
             </div>
         </div>
         <div class="flex-group align-center gap">
-            <div id="catalog-group">
+            <div class="catalog-antique-text-group">
                 <h2 class="center margin-bottom-25">
                     Antique
                 </h2>
@@ -129,7 +129,7 @@
 </div>
 
 <footer class="color-white background-color-black">
-    <div class="flex-group wrapper footer">
+    <div class="wrapper footer">
         <div>
             <img src="images/logo.png" alt="ロゴ" id="footer-logo">
         </div>


### PR DESCRIPTION
- PC画面時、"catalog"とそれに付随するテキストが画像の右隣ではなく下に表示されていたため、当該セクションのmax-widthを設定する形で修正しました。
  - 最大幅が設定されない故に、当該セクションが親要素の横幅まで拡大していたため。
- フレックスアイテムの折り返しが自然となるよう、メディアクエリを追加しました。
  - 各セクション内コンテンツの横幅の合計値を条件としました。


- PC
https://github.com/user-attachments/assets/089db4e8-be49-49e0-b64b-b486b6496296

- PC（581px < ビューポート横幅 <= 1041px）
https://github.com/user-attachments/assets/7cd6a015-7fc5-49ee-9058-34ea395ae94f

- スマホ（375px < ビューポート横幅 <= 581px）
https://github.com/user-attachments/assets/0ad7c858-4791-4b41-8945-ada5acd9ce5e


- スマホ（ビューポート横幅 <= 375px）
https://github.com/user-attachments/assets/a83f126b-eaf8-48a5-9de7-8787b0bb0e7f

